### PR TITLE
Add German translation

### DIFF
--- a/public/locales/de/common.yml
+++ b/public/locales/de/common.yml
@@ -1,0 +1,6 @@
+title: CovidPass
+subtitle: Fügen Sie Ihre digitalen EU COVID-Impfzertifikate Ihrer bevorzugten Wallet-App hinzu.
+privacyPolicy: Datenschutzrichtlinie
+donate: Spenden
+gitHub: GitHub
+imprint: Impressum

--- a/public/locales/de/errors.yml
+++ b/public/locales/de/errors.yml
@@ -1,0 +1,14 @@
+noFileOrQrCode: Bitte scannen Sie einen QR-Code, oder wählen Sie eine Datei aus
+signatureFailed: Fehler beim Signieren der Karte auf dem Server
+decodingFailed: Dekodierung der QR-Code-Daten fehlgeschlagen
+invalidColor: Ungültige Farbe
+vaccinationInfo: Impfinformationen konnten nicht gelesen werden
+nameMissing: Name konnte nicht gelesen werden
+dobMissing: Geburtsdatum konnte nicht gelesen werden
+invalidMedicalProduct: Ungültiges Medizinprodukt
+invalidCountryCode: Ungültiger Ländercode
+invalidManufacturer: Ungültiger Hersteller
+invalidFileType: Ungültiger Dateityp
+couldNotDecode: Dekodierung aus QR-Code fehlgeschlagen
+couldNotFindQrCode: QR-Code konnte in der ausgewählten Datei nicht gefunden werden
+invalidQrCode: Ungültiger QR-Code

--- a/public/locales/de/imprint.yml
+++ b/public/locales/de/imprint.yml
@@ -1,0 +1,27 @@
+heading: Information according to § 5 TMG
+contact: Contact
+euDisputeResolution: EU Dispute Resolution
+euDisputeResolutionParagraph: |
+  The European Commission provides a platform for online dispute resolution (OS) https://ec.europa.eu/consumers/odr.
+  You can find our e-mail address in the imprint above.
+consumerDisputeResolution: Consumer dispute resolution / universal arbitration board
+consumerDisputeResolutionParagraph: We are not willing or obliged to participate in dispute resolution proceedings before a consumer arbitration board.
+liabilityForContents: Liability for contents
+liabilityForContentsParagraph: |
+  As a service provider, we are responsible for our own content on these pages in accordance with § 7 paragraph 1 TMG under the general laws. 
+  According to §§ 8 to 10 TMG, we are not obligated to monitor transmitted or stored information or to investigate circumstances that indicate illegal activity. 
+  Obligations to remove or block the use of information under the general laws remain unaffected. 
+  However, liability in this regard is only possible from the point in time at which a concrete infringement of the law becomes known. 
+  If we become aware of any such infringements, we will remove the relevant content immediately.
+liabilityForLinks: Liability for links
+liabilityForLinksParagraph: |
+  Our offer contains links to external websites of third parties, on whose contents we have no influence. 
+  Therefore, we cannot assume any liability for these external contents.
+  The respective provider or operator of the sites is always responsible for the content of the linked sites. 
+  The linked pages were checked for possible legal violations at the time of linking.
+  Illegal contents were not recognizable at the time of linking. 
+  However, a permanent control of the contents of the linked pages is not reasonable without concrete evidence of a violation of the law. 
+  If we become aware of any infringements, we will remove such links immediately.
+credits: Credits
+creditsSource: With excerpts from https://www.e-recht24.de/impressum-generator.html
+creditsTranslation: Translated with https://www.DeepL.com/Translator (free version)

--- a/public/locales/de/index.yml
+++ b/public/locales/de/index.yml
@@ -1,0 +1,26 @@
+iosHint: Benutzen Sie unter iOS bitte Safari.
+errorClose: Schließen
+selectCertificate: Zertifikate auswählen
+selectCertificateDescription: |
+  Bitte scannen Sie den QR-Code auf Ihrem Zertifikat oder wählen Sie einen Screenshot oder eine PDF-Datei mit dem QR-Code aus. 
+  Bitte beachten Sie, dass die Auswahl einer Datei direkt von der Kamera nicht unterstützt wird. 
+stopCamera: Kamera stoppen
+startCamera: Kamera starten
+openFile: Datei auswählen (PDF, PNG)
+foundQrCode: QR-Code gefunden!
+pickColor: Fareb auswählen
+pickColorDescription: Wählen Sie eine Hintergrundfarbe für Ihre Karte aus.
+colorWhite: Weiß
+colorBlack: Schwarz
+colorGrey: Grau
+colorGreen: Grün
+colorIndigo: Indigo
+colorBlue: Blau
+colorPurple: Lila
+colorTeal: Blaugrün
+addToWallet: Zu Wallet hinzufügen
+dataPrivacyDescription: |
+  Datenschutz hat einen besonders hohen Stellenwert, wenn es um die Verarbeitung von gesundheitsbezogenen Daten geht. 
+  Damit Sie eine fundierte Entscheidung treffen können, lesen Sie bitte die
+iAcceptThe: Ich akzeptiere die
+privacyPolicy: Datenschutzrichtlinie

--- a/public/locales/de/privacy.yml
+++ b/public/locales/de/privacy.yml
@@ -1,0 +1,57 @@
+gdprNotice: |
+  Our privacy policy is based on the terms used by the European legislator 
+  for the adoption of the General Data Protection Regulation (GDPR).
+generalInfo: General information
+generalInfoProcess: |
+  The whole process of generating the pass file happens locally in your browser. 
+  For the signing step, only a hashed representation of your data is sent to the server.
+generalInfoStoring: Your data is not stored beyond the active browser session and the site does not use cookies.
+generalInfoThirdParties: No data is sent to third parties.
+generalInfoHttps: We transmit your data securely over https.
+generalInfoLocation: Our server is hosted in Nuremberg, Germany.
+generalInfoGitHub: The source code of this site is available on 
+generalInfoLockScreen: By default, Apple Wallet passes are accessible from the lock screen. This can be changed in the
+settings: settings
+generalInfoProvider: |
+  The server provider processes data to provide this site. 
+  In order to better understand what measures they take to protect your data, please also read their
+privacyPolicy: privacy policy
+andThe: and the
+dataPrivacyFaq: data privacy FAQ
+contact: Contact
+email: Email
+website: Website
+process: Simplified  of the process
+processFirst: First, the following steps happen locally in your browser 
+processSecond: Second, the following steps happen on our server
+processThird: Finally, the following steps happen locally in your browser
+processRecognizing: Recognizing and extracting the QR code data from your selected certificate
+processDecoding: Decoding your personal and health-related data from the QR code payload
+processAssembling: Assembling an incomplete pass file out of your data
+processGenerating: Generating a file containing hashes of the data stored in the pass file
+processSending: Sending only the file containing the hashes to our server
+processReceiving: Receiving and checking the hashes which were generated locally
+processSigning: Signing the file containing the hashes
+processSendingBack: Sending the signature back
+processCompleting: Assembling the signed pass file out of the incomplete file generated locally and the signature
+processSaving: Saving the file on your device
+locallyProcessedData: Locally processed data
+the: The
+schema: Digital Covid Certificate Schema
+specification: contains a detailed specification of which data can be contained in the QR code and will be processed in your browser.
+serverProvider: Server provider
+serverProviderIs: Our server provider is
+logFiles: The following data may be collected and stored in the server log files
+logFilesBrowser: The browser types and versions used
+logFilesOs: The operating system used by the accessing system
+logFilesReferrer: The website from which an accessing system reaches our website (so-called referrers)
+logFilesTime: The date and time of access
+logFilesIpAddress: The pseudonymised IP addresses
+rights: Your rights
+rightsGranted: In accordance with the GDPR you have the following rights
+rightsAccess: Right of access to your data; You have the right to know what data has been collected about you and how it was processed.
+rightsErasure:  Right to be forgotten; Erasure of your personal data.
+rightsRectification: Right of rectification; You have the right to correct inaccurate data.
+rightsPortability:  Right of data portability; You have the right to transfer your data from one processing system into another.
+thirdParties: Third parties linked
+appleSync: Apple may sync your passes via iCloud


### PR DESCRIPTION
This commit adds the German translation for all files but `imprint.yml` and `privacy.yml`.

If I should remove the untranslated files `imprint.yml` & `privacy.yml` from the German folder, so that the fallback language is used, just give me a hint and I'll delete them.

Thank you for this great project! 