### PR TITLE
Update Disclaimer text on payload.ts to EU commission set end date

### DIFF
--- a/src/payload.ts
+++ b/src/payload.ts
@@ -208,7 +208,7 @@ export class Payload {
                     {
                         key: "disclaimer",
                         label: "Disclaimer",
-                        value: "This certificate is only valid in combination with the ID card of the certificate holder and expires one year + 14 days after the last dose. The validity of this certificate was not checked by CovidPass."
+                        value: "This certificate is only valid in combination with the ID card of the certificate holder and expires 30.6.2022. The validity of this certificate was not checked by CovidPass."
                     }
                 ]);
                 break;

--- a/src/payload.ts
+++ b/src/payload.ts
@@ -208,7 +208,7 @@ export class Payload {
                     {
                         key: "disclaimer",
                         label: "Disclaimer",
-                        value: "This certificate is only valid in combination with the ID card of the certificate holder and expires 30.6.2022. The validity of this certificate was not checked by CovidPass."
+                        value: "This certificate is only valid in combination with the ID card of the certificate holder and expires 30 June 2022. The validity of this certificate was not checked by CovidPass."
                     }
                 ]);
                 break;


### PR DESCRIPTION
Update disclaimer pass expire be as EU set date of 30.6.2022

Info: https://ec.europa.eu/commission/presscorner/detail/en/QANDA_21_2781

This was confirmed by Social Insurance Institution of Finland