### PR TITLE
Fix decoder for third dose - fixes #124

### DIFF
--- a/src/decode.ts
+++ b/src/decode.ts
@@ -20,6 +20,10 @@ export function typedArrayToBuffer(array: Uint8Array): ArrayBuffer {
 }
 
 export function decodeData(data: string): Object {
+    if (data.startsWith('https://')) {
+        var url = new URL(data);
+        data = decodeURIComponent(url.hash.substring(1));
+    }
 
     if (data.startsWith('HC1')) {
         data = data.substring(3);


### PR DESCRIPTION
The QR Code I've downloaded from Ameli for my third dose has a new data format. It's a URL with the certificate stored in the hash.